### PR TITLE
Initialize basic FastAPI backend and Next.js expense page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# expensebuddy
+# ExpenseBuddy
+
+This project is a simple expense tracking application with a FastAPI backend and a Next.js frontend.
+
+## Backend
+
+The backend is located in the `backend` directory and uses **FastAPI**. To run it locally:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+The API will start on `http://localhost:8000` with the following endpoints:
+
+- `GET /expenses` – list expenses
+- `POST /expenses` – create a new expense
+- `GET /expenses/{id}` – get a specific expense
+- `DELETE /expenses/{id}` – delete an expense
+
+## Frontend
+
+The frontend lives in the `frontend` directory and is built with **Next.js**. To start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser. The page allows you to view and add expenses using the backend API.
+

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,7 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "ExpenseBuddy"
+    allowed_hosts: list[str] = ["*"]
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import List
+from uuid import uuid4
+from datetime import date
+
+from .core.config import settings
+
+class ExpenseBase(BaseModel):
+    description: str
+    amount: float
+    date: date = date.today()
+
+class Expense(ExpenseBase):
+    id: str
+
+app = FastAPI(title=settings.app_name)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_hosts,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+_expenses: List[Expense] = []
+
+@app.get("/expenses", response_model=List[Expense])
+def list_expenses() -> List[Expense]:
+    return _expenses
+
+@app.post("/expenses", response_model=Expense)
+def create_expense(expense: ExpenseBase) -> Expense:
+    new_expense = Expense(id=str(uuid4()), **expense.model_dump())
+    _expenses.append(new_expense)
+    return new_expense
+
+@app.get("/expenses/{expense_id}", response_model=Expense)
+def get_expense(expense_id: str) -> Expense:
+    for expense in _expenses:
+        if expense.id == expense_id:
+            return expense
+    raise HTTPException(status_code=404, detail="Expense not found")
+
+@app.delete("/expenses/{expense_id}", status_code=204)
+def delete_expense(expense_id: str) -> None:
+    for i, expense in enumerate(_expenses):
+        if expense.id == expense_id:
+            del _expenses[i]
+            return
+    raise HTTPException(status_code=404, detail="Expense not found")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,103 +1,70 @@
-import Image from "next/image";
+import { useEffect, useState, FormEvent } from "react";
+
+interface Expense {
+  id: string;
+  description: string;
+  amount: number;
+  date: string;
+}
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [description, setDescription] = useState("");
+  const [amount, setAmount] = useState("");
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+  useEffect(() => {
+    fetch("http://localhost:8000/expenses")
+      .then((res) => res.json())
+      .then(setExpenses)
+      .catch(() => {});
+  }, []);
+
+  async function addExpense(e: FormEvent) {
+    e.preventDefault();
+    const resp = await fetch("http://localhost:8000/expenses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ description, amount: parseFloat(amount) }),
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      setExpenses([...expenses, data]);
+      setDescription("");
+      setAmount("");
+    }
+  }
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Expenses</h1>
+      <ul className="mb-4">
+        {expenses.map((exp) => (
+          <li key={exp.id} className="mb-1">
+            {exp.description} - ${'{'}exp.amount.toFixed(2){'}'}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={addExpense} className="flex gap-2">
+        <input
+          className="border p-1"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          required
+        />
+        <input
+          className="border p-1"
+          placeholder="Amount"
+          type="number"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          required
+        />
+        <button className="border px-2" type="submit">
+          Add
+        </button>
+      </form>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- flesh out FastAPI backend with simple in-memory expense APIs
- expose CORS settings and a small configuration module
- add required backend dependencies
- implement a minimal Next.js page to view and add expenses
- document how to run the backend and frontend

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685431a3cd74832da19ba1b0196a412b