### PR TITLE
Add Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@ npm run dev
 
 Open `http://localhost:3000` in your browser. The page allows you to view and add expenses using the backend API.
 
+## Docker
+
+Docker configurations are provided for development and production.
+
+### Development
+
+Run the services with hot-reload using the development compose file:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+### Production
+
+Build optimized images and run them with:
+
+```bash
+docker compose -f docker-compose.prod.yml up --build
+```
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: ./frontend
+    command: npm run dev
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
+    depends_on:
+      - backend

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: ./frontend
+    environment:
+      - NEXT_PUBLIC_API_URL=http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine AS prod
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -11,9 +11,10 @@ export default function Home() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [description, setDescription] = useState("");
   const [amount, setAmount] = useState("");
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
   useEffect(() => {
-    fetch("http://localhost:8000/expenses")
+    fetch(`${API_URL}/expenses`)
       .then((res) => res.json())
       .then(setExpenses)
       .catch(() => {});
@@ -21,7 +22,7 @@ export default function Home() {
 
   async function addExpense(e: FormEvent) {
     e.preventDefault();
-    const resp = await fetch("http://localhost:8000/expenses", {
+    const resp = await fetch(`${API_URL}/expenses`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ description, amount: parseFloat(amount) }),


### PR DESCRIPTION
## Summary
- dockerize backend and frontend
- add compose files for dev and prod
- update Next.js frontend to use API URL env
- document Docker usage

## Testing
- `npm run lint` *(fails: next not found)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68543408be0c832d97707e8a199ac2b6