### PR TITLE
Add use client directive to Next.js page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState, FormEvent } from "react";
 
 interface Expense {


### PR DESCRIPTION
## Summary
- mark the root page as a client component in the Next.js frontend

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543dddc8cc832db819f10f6a28d71e