### PR TITLE
Update default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ SQLite database for persistence. To run it locally:
 ```bash
 cd backend
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+uvicorn app.main:app --reload --port 8001
 ```
 
 An `expenses.db` SQLite file will be created automatically in the `backend`
 folder to store your data.
 
-The API will start on `http://localhost:8000` with the following endpoints:
+The API will start on `http://localhost:8001` with the following endpoints:
 
 - `GET /expenses` – list expenses
 - `POST /expenses` – create a new expense
@@ -33,7 +33,7 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:3000` in your browser. The page allows you to view and add expenses using the backend API.
+Open `http://localhost:3001` in your browser. The page allows you to view and add expenses using the backend API.
 
 ## Docker
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,5 +7,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8001
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,11 +3,11 @@ services:
   backend:
     build:
       context: ./backend
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8001 --reload
     volumes:
       - ./backend:/app
     ports:
-      - "8000:8000"
+      - "8001:8001"
   frontend:
     build:
       context: ./frontend
@@ -15,8 +15,9 @@ services:
     volumes:
       - ./frontend:/app
     ports:
-      - "3000:3000"
+      - "3001:3001"
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8001
+      - PORT=3001
     depends_on:
       - backend

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,13 +4,14 @@ services:
     build:
       context: ./backend
     ports:
-      - "8000:8000"
+      - "8001:8001"
   frontend:
     build:
       context: ./frontend
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8001
+      - PORT=3001
     ports:
-      - "3000:3000"
+      - "3001:3001"
     depends_on:
       - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 FROM node:18-alpine AS prod
 WORKDIR /app
 ENV NODE_ENV=production
+ENV PORT=3001
 COPY --from=build /app .
-EXPOSE 3000
+EXPOSE 3001
 CMD ["npm", "start"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [description, setDescription] = useState("");
   const [amount, setAmount] = useState("");
-  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001";
 
   useEffect(() => {
     fetch(`${API_URL}/expenses`)


### PR DESCRIPTION
## Summary
- switch backend to port 8001
- switch frontend to port 3001

## Testing
- `python -m py_compile backend/app/main.py backend/app/core/config.py`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544547b438832d822a13c5553fe1d7