### PR TITLE
Fix amount display in frontend

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
       <ul className="mb-4">
         {expenses.map((exp) => (
           <li key={exp.id} className="mb-1">
-            {exp.description} - ${'{'}exp.amount.toFixed(2){'}'}
+            {exp.description} - ${exp.amount.toFixed(2)}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- fix `toFixed` display on the expenses list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6856196c9340832dbe3e52826b79394b